### PR TITLE
Rewrite metadata to docker format

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,7 @@ jobs:
           labels: |
             name=rocky-toolbox
             version=${{ matrix.version }}
+          oci: true
           tags: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_ACCOUNT }}/rocky-toolbox:${{ matrix.version }}
 
       - name: Push image
@@ -57,3 +58,5 @@ jobs:
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}
+          extra-args: |
+            --format=v2s2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,5 @@ jobs:
           labels: |
             name=rocky-toolbox
             version=${{ matrix.version }}
+          oci: true
           tags: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_ACCOUNT }}/rocky-toolbox:${{ matrix.version }}


### PR DESCRIPTION
This is a workaround to the issue, that leads from the buildah version 1.23.1, which is part of Ubuntu 22.04 LTS...
containers/buildah issues/4395

Hopefully some time in the future this will work naturally.