### PR TITLE
Add ppc64le and s390x builds for 9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,10 @@ jobs:
     strategy:
       matrix:
         version:
-          - 8
-          - 9
+          - major: 8
+            arch: 'amd64, arm64'
+          - major: 9
+            arch: 'amd64, arm64, ppc64le, s390x'
     runs-on: ubuntu-latest
     name: Build and push toolbox images
     steps:
@@ -40,18 +42,18 @@ jobs:
         uses: redhat-actions/buildah-build@v2
         id: build-image
         with:
-          archs: amd64, arm64
+          archs: ${{ matrix.version.arch }}
           build-args: |
-            ImageVersion=${{ matrix.version }}
+            ImageVersion=${{ matrix.version.major }}
           containerfiles: |
             ./Dockerfile
           extra-args: |
             --squash
           labels: |
             name=rocky-toolbox
-            version=${{ matrix.version }}
+            version=${{ matrix.version.major }}
           oci: true
-          tags: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_ACCOUNT }}/rocky-toolbox:${{ matrix.version }}
+          tags: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_ACCOUNT }}/rocky-toolbox:${{ matrix.version.major }}
 
       - name: Push image
         uses: redhat-actions/push-to-registry@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,10 @@ jobs:
     strategy:
       matrix:
         version:
-          - 8
-          - 9
+          - major: 8
+            arch: 'amd64, arm64'
+          - major: 9
+            arch: 'amd64, arm64, ppc64le, s390x'
     runs-on: ubuntu-latest
     name: Build and push toolbox images
     steps:
@@ -31,15 +33,15 @@ jobs:
         uses: redhat-actions/buildah-build@v2
         id: build-image
         with:
-          archs: amd64, arm64
+          archs: ${{ matrix.version.arch }}
           build-args: |
-            ImageVersion=${{ matrix.version }}
+            ImageVersion=${{ matrix.version.major }}
           containerfiles: |
             ./Dockerfile
           extra-args: |
             --squash
           labels: |
             name=rocky-toolbox
-            version=${{ matrix.version }}
+            version=${{ matrix.version.major }}
           oci: true
-          tags: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_ACCOUNT }}/rocky-toolbox:${{ matrix.version }}
+          tags: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_ACCOUNT }}/rocky-toolbox:${{ matrix.version.major }}


### PR DESCRIPTION
As it was already working that great for the init, micro builds, this change introduces the matrix split for 8 and 9 to also build ppc64le and s390x for 9!