### PR TITLE
Add support for multiple registries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,6 @@ on:
   schedule:
     - cron: "30 0 * * 0"
 
-env:
-  IMAGE_REGISTRY: docker.io
-  IMAGE_ACCOUNT: rockylinux
-
 jobs:
   run_toolbox_builds:
     strategy:
@@ -21,6 +17,13 @@ jobs:
             arch: 'amd64, arm64'
           - major: 9
             arch: 'amd64, arm64, ppc64le, s390x'
+        registry:
+          - domain: docker.io
+            account: rockylinux
+            secret: DOCKER
+          - domain: quay.io
+            account: rockylinux
+            secret: QUAY
     runs-on: ubuntu-latest
     name: Build and push toolbox images
     steps:
@@ -34,10 +37,10 @@ jobs:
       - name: Setup Registry login
         uses: redhat-actions/podman-login@v1
         with:
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
-          registry: ${{ env.IMAGE_REGISTRY }}
-      
+          username: ${{ secrets[format('{0}_USERNAME', matrix.registry.secret)] }}
+          password: ${{ secrets[format('{0}_TOKEN', matrix.registry.secret)] }}
+          registry: ${{ matrix.registry.domain }}
+
       - name: Build image
         uses: redhat-actions/buildah-build@v2
         id: build-image
@@ -53,7 +56,7 @@ jobs:
             name=rocky-toolbox
             version=${{ matrix.version.major }}
           oci: true
-          tags: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_ACCOUNT }}/rocky-toolbox:${{ matrix.version.major }}
+          tags: ${{ matrix.registry.domain }}/${{ matrix.registry.account }}/rocky-toolbox:${{ matrix.version.major }}
 
       - name: Push image
         uses: redhat-actions/push-to-registry@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,8 @@ jobs:
             --squash
           labels: |
             name=rocky-toolbox
-            version=${{ matrix.version.major }}
+            org.opencontainers.image.title=rocky-toolbox
+            org.opencontainers.image.version=${{ matrix.version.major }}
           oci: true
           tags: ${{ matrix.registry.domain }}/${{ matrix.registry.account }}/rocky-toolbox:${{ matrix.version.major }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,6 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
-env:
-  IMAGE_REGISTRY: docker.io
-  IMAGE_ACCOUNT: rockylinux
-
 jobs:
   run_toolbox_builds:
     strategy:
@@ -19,6 +15,13 @@ jobs:
             arch: 'amd64, arm64'
           - major: 9
             arch: 'amd64, arm64, ppc64le, s390x'
+        registry:
+          - domain: docker.io
+            account: rockylinux
+            secret: DOCKER
+          - domain: quay.io
+            account: rockylinux
+            secret: QUAY
     runs-on: ubuntu-latest
     name: Build and push toolbox images
     steps:
@@ -28,7 +31,14 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y qemu-user-static
-      
+
+      - name: Setup Registry login
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: ${{ secrets[format('{0}_USERNAME', matrix.registry.secret)] }}
+          password: ${{ secrets[format('{0}_TOKEN', matrix.registry.secret)] }}
+          registry: ${{ matrix.registry.domain }}
+
       - name: Build image
         uses: redhat-actions/buildah-build@v2
         id: build-image
@@ -44,4 +54,4 @@ jobs:
             name=rocky-toolbox
             version=${{ matrix.version.major }}
           oci: true
-          tags: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_ACCOUNT }}/rocky-toolbox:${{ matrix.version.major }}
+          tags: ${{ matrix.registry.domain }}/${{ matrix.registry.account }}/rocky-toolbox:${{ matrix.version.major }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
             --squash
           labels: |
             name=rocky-toolbox
-            version=${{ matrix.version.major }}
+            org.opencontainers.image.title=rocky-toolbox
+            org.opencontainers.image.version=${{ matrix.version.major }}
           oci: true
           tags: ${{ matrix.registry.domain }}/${{ matrix.registry.account }}/rocky-toolbox:${{ matrix.version.major }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,11 @@ FROM rockylinux/rockylinux:$ImageVersion
 
 LABEL com.github.containers.toolbox="true" \
       usage="This image is meant to be used with the toolbox command" \
-      summary="Base image for creating Rocky Linux toolbox containers" \
-      maintainer="Magauer Lukas <lukas@magauer.eu>"
+      org.opencontainers.image.authors="Magauer Lukas <lukas@magauer.eu>" \
+      org.opencontainers.image.description="Base image for creating Rocky Linux toolbox containers" \
+      org.opencontainers.image.licenses="BSD-3-Clause" \
+      org.opencontainers.image.url="https://github.com/rocky-linux/rocky-toolbox-images" \
+      org.opencontainers.image.vendor="Rocky Enterprise Software Foundation"
 
 COPY README.md /
 


### PR DESCRIPTION
@NeilHanlon To merge this PR it is needed to change the Secrets, the CI will also check now if the secrets are present -> will fail if not.

It's set up the same way as the 2nd layer sig-cloud images now, means needed steps before merging:
- Create CR repository in Quay
- Permit robot account there on the repo
- Add the Docker Hub and Quay robot accounts with the following names as secret:
  - `DOCKER_USERNAME`
  - `DOCKER_TOKEN`
  - `QUAY_USERNAME`
  - `QUAY_TOKEN`
If you think we don't want to push it to quay, I'm fine with that, it's then just the preperation to push it to our own CR, if that comes around some time (or GHCR), beside this should also use the robot account for Docker Hub.