### PR TITLE
Temporarily remove ppc64le

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
           - major: 8
             arch: 'amd64, arm64'
           - major: 9
-            arch: 'amd64, arm64, ppc64le, s390x'
+            arch: 'amd64, arm64, s390x'
     runs-on: ubuntu-latest
     name: Build and push toolbox images
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           - major: 8
             arch: 'amd64, arm64'
           - major: 9
-            arch: 'amd64, arm64, ppc64le, s390x'
+            arch: 'amd64, arm64, s390x'
     runs-on: ubuntu-latest
     name: Build and push toolbox images
     steps:


### PR DESCRIPTION
As ppc64le has still no image in the rockylinux:(8|9) image, this will remove ppc64le in the toolbox images.

This is a workaround and should be reverted as soon as they are available again.