### PR TITLE
Revert "As the ppc64le arch in the source image has not been availabl…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
           - major: 8
             arch: 'amd64, arm64'
           - major: 9
-            arch: 'amd64, arm64, s390x'
+            arch: 'amd64, arm64, ppc64le, s390x'
     runs-on: ubuntu-latest
     name: Build and push toolbox images
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           - major: 8
             arch: 'amd64, arm64'
           - major: 9
-            arch: 'amd64, arm64, s390x'
+            arch: 'amd64, arm64, ppc64le, s390x'
     runs-on: ubuntu-latest
     name: Build and push toolbox images
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG ImageVersion
 
-FROM rockylinux:$ImageVersion
+FROM rockylinux/rockylinux:$ImageVersion
 
 LABEL com.github.containers.toolbox="true" \
       usage="This image is meant to be used with the toolbox command" \


### PR DESCRIPTION
…e for months, this temporarily removes the arch in the builds as well as from the registry images (#10)"

This reverts commit 76faa4ddea7eab3085f28a6dacf611c33a7028d9.