### PR TITLE
Push with OCI metadata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,5 +64,3 @@ jobs:
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}
-          extra-args: |
-            --format=v2s2


### PR DESCRIPTION
As Ubuntu 24.04 builders are now available this works now!

![Screenshot from 2024-09-30 22-49-25](https://github.com/user-attachments/assets/6db4d16d-01ea-4ca8-8ac4-2ce41dc904f9)
